### PR TITLE
Add method to write without checksum

### DIFF
--- a/src/Lin_Interface.cpp
+++ b/src/Lin_Interface.cpp
@@ -308,6 +308,20 @@ void Lin_Interface::writeFrameClassic(uint8_t FrameID, uint8_t dataLen)
     HardwareSerial::end();
 } // void Lin_Interface::writeFrameClassic
 
+void Lin_Interface::writeFrameClassicNoChecksum(uint8_t FrameID, uint8_t dataLen)
+{
+    uint8_t ProtectedID = getProtectedID(FrameID);
+
+    startTransmission(ProtectedID);
+
+    for (int i = 0; i < dataLen; ++i)
+    {
+        HardwareSerial::write(LinMessage[i]); // Message (array from 1..8)
+    }
+    HardwareSerial::flush();
+    HardwareSerial::end();
+}
+
 /// Introduce Frame (Start UART, Break, Sync, PID)
 void Lin_Interface::startTransmission(uint8_t ProtectedID)
 {

--- a/src/Lin_Interface.hpp
+++ b/src/Lin_Interface.hpp
@@ -34,6 +34,7 @@ public:
 
     void writeFrame(uint8_t FrameID, uint8_t datalen);
     void writeFrameClassic(uint8_t FrameID, uint8_t datalen);
+    void writeFrameClassicNoChecksum(uint8_t FrameID, uint8_t datalen);
 
 protected:
     uint32_t m_bitCycles;


### PR DESCRIPTION
First, I want to apologize if my C++ coding style doesn't fully match the conventional standards—I'm more experienced in other languages but I did my best to have clean code.

I'm proposing a change to add method for writing to the LIN bus without automatically appending a checksum. The reason for this addition is that some vendors use proprietary checksum calculations, leading to scenarios where adding a standard checksum makes the packet invalid. This change would allow for copying data as is, without modification, ensuring compatibility with systems that expect non-standard checksums or handle checksum verification differently.

P.S. I use this approach to generate code in my [package analyser](https://github.com/logic-inspect/logic-inspect)